### PR TITLE
fix blog post uris

### DIFF
--- a/frontend/src/app/lib/queries/posts.ts
+++ b/frontend/src/app/lib/queries/posts.ts
@@ -15,6 +15,7 @@ export const GET_POST_BY_SLUG = `query GetPostByUri($slug: String!) {
       title
       content
       excerpt
+      uri
       author {
         ...AuthorToUser
       }
@@ -96,6 +97,7 @@ fragment RootQueryToPostConnectionEdgeFragment on RootQueryToPostConnectionEdge 
     title
     excerpt(format: RENDERED)
     slug
+    uri
     date
     featuredImage {
       node {

--- a/frontend/src/app/lib/types/posts/post.ts
+++ b/frontend/src/app/lib/types/posts/post.ts
@@ -11,6 +11,7 @@ export type Post = {
   title: string;
   excerpt: string;
   slug: string;
+  uri: string;
   date: string;
   featuredImage: Node<FeaturedImage>;
   author: Node<Author>;

--- a/frontend/src/components/core/Post/PostListItem.tsx
+++ b/frontend/src/components/core/Post/PostListItem.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 
 const PostListItem = (data: Post) => {
-  const { id, title, slug, excerpt, author, date, featuredImage, categories } =
+  const { id, title, uri, excerpt, author, date, featuredImage, categories } =
     data;
 
   const sourceUrl = featuredImage?.node?.sourceUrl;
@@ -18,7 +18,7 @@ const PostListItem = (data: Post) => {
         )}
         <ContentBlock content={excerpt} />
       </div>
-      <Link href={`blog/'${slug}`}>Read More &raquo;</Link>
+      <Link href={`${uri}`}>Read More &raquo;</Link>
       <p className="my-0">by {author.node.name}</p>
       <span>Date: {date} </span>
       <span> | </span>


### PR DESCRIPTION
Update WP to add `blog/` before post slugs

- Use post `uri` instead of `slug` for links